### PR TITLE
Add MarketFlow Studio personal UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@ __pycache__/
 *.env
 .env
 env/
+.venv/
 venv/
 ENV/
 venv.bak/
 *.sqlite3
+.pytest_cache/
 .ipynb_checkpoints/
 
 # VSCode
@@ -28,6 +30,11 @@ logs/
 .vpa/
 .vpa_memory.json
 .marketflow/
+.marketflow/logs/
+.marketflow/reports/
+.marketflow/memory/
+.marketflow/snapshot_reports/
+.marketflow/batch_reports_data/
 
 # Environment/config data
 .env.*
@@ -39,6 +46,12 @@ config.json
 *.csv
 *.parquet
 *.h5
+*.pkl
+*.sqlite
+*.db
+*_mc_summary.json
+*_mc_paths.html
+*_mc_hits.html
 data/
 cache/
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,14 @@ A personal local Streamlit interface is available on the feature branch:
 streamlit run apps/marketflow_studio.py
 ```
 
-The app can run analysis, load generated reports, preview annotated CSV files, and show a basic Wyckoff candlestick chart.
+The app can:
+
+- run analysis
+- load generated reports
+- preview annotated CSV files
+- show a basic Wyckoff candlestick chart
+- rank strategy candidates
+- run simple Monte Carlo simulations
 
 ## Overview: Main Data Flow in MarketFlow
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ is designed for clarity, testability, and ease of extension.
     marketflow analyze AAPL --timeframes 1d 4h 1h
     ```
 
+## MarketFlow Studio
+
+A personal local Streamlit interface is available on the feature branch:
+
+```bash
+streamlit run apps/marketflow_studio.py
+```
+
+The app can run analysis, load generated reports, preview annotated CSV files, and show a basic Wyckoff candlestick chart.
+
 ## Overview: Main Data Flow in MarketFlow
 
 The MarketFlow system is organized around the facade pattern (via MarketflowFacade), which orchestrates a modular pipeline for multi-timeframe financial analysis. The main pathway is:

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -339,6 +339,62 @@ def _render_strategy_error(strategy_result: dict[str, Any]) -> None:
             st.code(strategy_result["traceback"], language="python")
 
 
+def _strategy_diagnostics_dataframe(diagnostics: dict[str, Any]) -> Any:
+    """Return a compact ticker-check table for strategy diagnostics."""
+    ticker_checks = diagnostics.get("ticker_checks") or {}
+    rows = []
+    for ticker, check in ticker_checks.items():
+        rows.append(
+            {
+                "ticker": ticker,
+                "ticker_folder_found": check.get("ticker_folder_found", False),
+                "matching_csv_count": len(check.get("matching_timeframe_csvs") or []),
+                "csv_count": len(check.get("csv_candidates") or []),
+                "ticker_folder": check.get("ticker_folder"),
+            }
+        )
+    return rows
+
+
+def _render_strategy_diagnostics(strategy_result: dict[str, Any]) -> None:
+    """Render strategy diagnostics in a collapsed expander."""
+    diagnostics = strategy_result.get("diagnostics") or {}
+    if not diagnostics:
+        return
+
+    with st.expander("Strategy diagnostics"):
+        st.write(f"Report root: `{diagnostics.get('report_root')}`")
+        st.write(f"Report root exists: `{diagnostics.get('report_root_exists')}`")
+        latest_batch = diagnostics.get("latest_batch_folder")
+        if latest_batch:
+            st.write(f"Latest batch folder: `{latest_batch}`")
+        else:
+            st.write("Latest batch folder: none found")
+        st.write(
+            f"Latest batch folder exists: `{diagnostics.get('latest_batch_folder_exists')}`"
+        )
+        st.write(f"Requested tickers: `{', '.join(diagnostics.get('requested_tickers') or [])}`")
+        st.write(f"Selected timeframe: `{diagnostics.get('requested_timeframe')}`")
+
+        filters = diagnostics.get("filters") or {}
+        st.write("Filters")
+        st.json(filters)
+
+        notes = diagnostics.get("notes") or []
+        if notes:
+            st.write("Notes")
+            for note in notes:
+                st.write(f"- {note}")
+
+        ticker_rows = _strategy_diagnostics_dataframe(diagnostics)
+        if ticker_rows:
+            st.write("Ticker checks")
+            st.dataframe(ticker_rows, use_container_width=True)
+
+        st.write("Raw diagnostics")
+        st.json(diagnostics)
+
+
 def _render_strategy_results(strategy_result: dict[str, Any] | None) -> None:
     """Render strategy ranking output."""
     if not strategy_result:
@@ -351,6 +407,7 @@ def _render_strategy_results(strategy_result: dict[str, Any] | None) -> None:
 
     if not strategy_result.get("success"):
         _render_strategy_error(strategy_result)
+        _render_strategy_diagnostics(strategy_result)
         return
 
     dataframe = strategy_result.get("dataframe")
@@ -359,10 +416,12 @@ def _render_strategy_results(strategy_result: dict[str, Any] | None) -> None:
             "No candidates passed the filters. Try a lower min RR, a different timeframe, "
             "or confirm reports exist for those tickers."
         )
+        _render_strategy_diagnostics(strategy_result)
         return
 
     st.write(f"Result count: `{len(dataframe)}`")
     st.dataframe(dataframe, use_container_width=True)
+    _render_strategy_diagnostics(strategy_result)
 
     results = strategy_result.get("results") or []
     labels = [

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -15,7 +15,12 @@ if str(PROJECT_ROOT) not in sys.path:
 from marketflow.services.analysis_service import run_single_ticker
 from marketflow.services.report_index import (
     find_latest_ticker_report,
+    infer_timeframe_from_csv_name,
+    list_annotated_csv_files,
+    list_available_tickers,
+    list_report_date_folders,
     list_report_files,
+    load_csv_preview,
     load_report_json,
     load_summary_text,
 )
@@ -113,9 +118,10 @@ def _render_reports(result: dict[str, Any] | None) -> None:
         st.info("No report directory loaded.")
         return
 
-    st.write(f"Report directory: `{result['output_dir']}`")
+    report_dir = result["output_dir"]
+    st.write(f"Report directory: `{report_dir}`")
 
-    files = result.get("report_files") or []
+    files = list_report_files(report_dir) or result.get("report_files") or []
     if files:
         st.markdown("#### Generated Files")
         for file_path in files:
@@ -123,10 +129,66 @@ def _render_reports(result: dict[str, Any] | None) -> None:
     else:
         st.info("No generated files found in this directory.")
 
+    date_folders = list_report_date_folders()
+    if date_folders:
+        st.markdown("#### Report Date / Batch Folders")
+        for folder in date_folders:
+            st.write(f"- `{folder}`")
+
+    report_parent = str(Path(report_dir).parent)
+    tickers = list_available_tickers(report_parent)
+    if tickers:
+        st.markdown("#### Available Ticker Folders")
+        st.write(", ".join(f"`{ticker}`" for ticker in tickers))
+
     summary_text = result.get("summary_text")
     if summary_text:
         st.markdown("#### Summary")
         st.text(summary_text)
+
+
+def _render_csv_preview(result: dict[str, Any] | None) -> None:
+    """Render the CSV Preview tab."""
+    if not result or not result.get("output_dir"):
+        st.info("Load a report or run an analysis before previewing CSV files.")
+        return
+
+    report_dir = result["output_dir"]
+    report_path = Path(report_dir)
+    if not report_path.exists() or not report_path.is_dir():
+        st.warning(f"Report directory does not exist: {report_dir}")
+        return
+
+    csv_files = list_annotated_csv_files(report_dir)
+    if not csv_files:
+        st.info("No annotated CSV files found in this report directory.")
+        return
+
+    selected_csv = st.selectbox(
+        "CSV file",
+        options=csv_files,
+        format_func=lambda path: Path(path).name,
+    )
+    preview_rows = st.selectbox("Preview rows", options=[100, 250, 500, 1000], index=2)
+
+    timeframe = infer_timeframe_from_csv_name(selected_csv)
+    st.write(f"Filename: `{Path(selected_csv).name}`")
+    if timeframe:
+        st.write(f"Timeframe: `{timeframe}`")
+    else:
+        st.write("Timeframe: unknown")
+
+    dataframe = load_csv_preview(selected_csv, nrows=preview_rows)
+    if dataframe is None:
+        st.error("Could not load this CSV file for preview.")
+        return
+
+    st.write(f"Rows in preview: `{len(dataframe)}`")
+    st.write(f"Column count: `{len(dataframe.columns)}`")
+    st.write("Columns:")
+    st.write(", ".join(f"`{column}`" for column in dataframe.columns))
+
+    st.dataframe(dataframe, use_container_width=True)
 
 
 def _render_raw_json(result: dict[str, Any] | None) -> None:
@@ -163,13 +225,18 @@ def main() -> None:
             st.session_state.analysis_result = _load_latest_result(ticker)
 
     result = st.session_state.analysis_result
-    overview_tab, reports_tab, raw_json_tab = st.tabs(["Overview", "Reports", "Raw JSON"])
+    overview_tab, reports_tab, csv_tab, raw_json_tab = st.tabs(
+        ["Overview", "Reports", "CSV Preview", "Raw JSON"]
+    )
 
     with overview_tab:
         _render_overview(result)
 
     with reports_tab:
         _render_reports(result)
+
+    with csv_tab:
+        _render_csv_preview(result)
 
     with raw_json_tab:
         _render_raw_json(result)

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -365,14 +365,22 @@ def _render_strategy_diagnostics(strategy_result: dict[str, Any]) -> None:
     with st.expander("Strategy diagnostics"):
         st.write(f"Report root: `{diagnostics.get('report_root')}`")
         st.write(f"Report root exists: `{diagnostics.get('report_root_exists')}`")
+        batch_run_folders = diagnostics.get("batch_run_folders") or []
+        ignored_batch_like = diagnostics.get("ignored_batch_like_folders") or []
+        st.write(f"Valid batch run folders: `{len(batch_run_folders)}`")
         latest_batch = diagnostics.get("latest_batch_folder")
         if latest_batch:
-            st.write(f"Latest batch folder: `{latest_batch}`")
+            st.write(f"Latest valid batch folder: `{latest_batch}`")
         else:
-            st.write("Latest batch folder: none found")
+            st.write("Latest valid batch folder: none found")
         st.write(
-            f"Latest batch folder exists: `{diagnostics.get('latest_batch_folder_exists')}`"
+            f"Latest valid batch folder exists: `{diagnostics.get('latest_batch_folder_exists')}`"
         )
+        if ignored_batch_like:
+            st.write(f"Ignored batch-like folders: `{len(ignored_batch_like)}`")
+            st.caption("Folders such as `batch_csv_*` are ignored as real batch runs.")
+            for folder in ignored_batch_like[:10]:
+                st.write(f"- `{folder}`")
         st.write(f"Requested tickers: `{', '.join(diagnostics.get('requested_tickers') or [])}`")
         st.write(f"Selected timeframe: `{diagnostics.get('requested_timeframe')}`")
 

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -1,0 +1,170 @@
+"""Minimal local Streamlit interface for MarketFlow."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import streamlit as st
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from marketflow.services.analysis_service import run_single_ticker
+from marketflow.services.report_index import (
+    find_latest_ticker_report,
+    list_report_files,
+    load_report_json,
+    load_summary_text,
+)
+
+
+DEFAULT_TIMEFRAMES = ["1d", "4h", "1h"]
+TIMEFRAME_OPTIONS = ["1d", "4h", "1h", "15m", "5m"]
+
+
+def _load_latest_result(ticker: str) -> dict[str, Any]:
+    """Load the newest generated report bundle for a ticker."""
+    report_dir = find_latest_ticker_report(ticker)
+    report_json = load_report_json(report_dir, ticker) if report_dir else None
+    summary_text = load_summary_text(report_dir, ticker) if report_dir else None
+
+    return {
+        "ticker": ticker,
+        "narrative": summary_text or "",
+        "output_dir": report_dir,
+        "success": bool(report_dir),
+        "error": None if report_dir else f"No report found for {ticker}.",
+        "report_json": report_json,
+        "summary_text": summary_text,
+        "report_files": list_report_files(report_dir) if report_dir else [],
+    }
+
+
+def _nested_get(data: dict[str, Any] | None, keys: list[str]) -> Any:
+    """Read a nested value from a dictionary, returning None if any key is missing."""
+    current: Any = data
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _display_value(label: str, value: Any) -> None:
+    """Display a scalar value if it is available."""
+    if value is not None and value != "":
+        st.metric(label, value)
+
+
+def _render_overview(result: dict[str, Any] | None) -> None:
+    """Render the Overview tab."""
+    if not result:
+        st.info("Run an analysis or load the latest report to view an overview.")
+        return
+
+    report_json = result.get("report_json") or {}
+    signal = report_json.get("signal") if isinstance(report_json, dict) else {}
+    risk = report_json.get("risk_assessment") if isinstance(report_json, dict) else {}
+
+    st.subheader(result.get("ticker") or "Ticker")
+    if result.get("output_dir"):
+        st.caption(f"Output directory: {result['output_dir']}")
+
+    if result.get("error"):
+        st.warning(result["error"])
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        _display_value("Current Price", report_json.get("current_price"))
+        _display_value("Stop Loss", _nested_get(risk, ["stop_loss"]))
+    with col2:
+        _display_value("Signal Type", _nested_get(signal, ["type"]))
+        _display_value("Take Profit", _nested_get(risk, ["take_profit"]))
+    with col3:
+        _display_value("Signal Strength", _nested_get(signal, ["strength"]))
+        _display_value("Risk/Reward", _nested_get(risk, ["risk_reward_ratio"]))
+
+    summary_text = result.get("summary_text") or result.get("narrative")
+    if summary_text:
+        st.markdown("#### Summary Preview")
+        st.text_area(
+            "Summary Preview",
+            value=summary_text[:4000],
+            height=260,
+            label_visibility="collapsed",
+        )
+
+
+def _render_reports(result: dict[str, Any] | None) -> None:
+    """Render the Reports tab."""
+    if not result or not result.get("output_dir"):
+        st.info("No report directory loaded.")
+        return
+
+    st.write(f"Report directory: `{result['output_dir']}`")
+
+    files = result.get("report_files") or []
+    if files:
+        st.markdown("#### Generated Files")
+        for file_path in files:
+            st.write(f"- `{file_path}`")
+    else:
+        st.info("No generated files found in this directory.")
+
+    summary_text = result.get("summary_text")
+    if summary_text:
+        st.markdown("#### Summary")
+        st.text(summary_text)
+
+
+def _render_raw_json(result: dict[str, Any] | None) -> None:
+    """Render the Raw JSON tab."""
+    report_json = result.get("report_json") if result else None
+    if report_json:
+        st.json(report_json)
+    else:
+        st.info("No JSON report is loaded.")
+
+
+def main() -> None:
+    """Run the MarketFlow Studio Streamlit app."""
+    st.set_page_config(page_title="MarketFlow Studio", layout="wide")
+    st.title("MarketFlow Studio")
+
+    if "analysis_result" not in st.session_state:
+        st.session_state.analysis_result = None
+
+    with st.sidebar:
+        st.header("Analysis")
+        ticker = st.text_input("Ticker", value="AAPL").strip()
+        timeframes = st.multiselect(
+            "Timeframes",
+            options=TIMEFRAME_OPTIONS,
+            default=DEFAULT_TIMEFRAMES,
+        )
+
+        if st.button("Run Analysis", type="primary"):
+            with st.spinner(f"Running analysis for {ticker}..."):
+                st.session_state.analysis_result = run_single_ticker(ticker, timeframes)
+
+        if st.button("Load Latest Report"):
+            st.session_state.analysis_result = _load_latest_result(ticker)
+
+    result = st.session_state.analysis_result
+    overview_tab, reports_tab, raw_json_tab = st.tabs(["Overview", "Reports", "Raw JSON"])
+
+    with overview_tab:
+        _render_overview(result)
+
+    with reports_tab:
+        _render_reports(result)
+
+    with raw_json_tab:
+        _render_raw_json(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -22,7 +22,7 @@ from marketflow.services.report_index import (
 
 
 DEFAULT_TIMEFRAMES = ["1d", "4h", "1h"]
-TIMEFRAME_OPTIONS = ["1d", "4h", "1h", "15m", "5m"]
+TIMEFRAME_OPTIONS = ["1mo", "1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m"]
 
 
 def _load_latest_result(ticker: str) -> dict[str, Any]:
@@ -37,6 +37,8 @@ def _load_latest_result(ticker: str) -> dict[str, Any]:
         "output_dir": report_dir,
         "success": bool(report_dir),
         "error": None if report_dir else f"No report found for {ticker}.",
+        "error_type": None,
+        "traceback": None,
         "report_json": report_json,
         "summary_text": summary_text,
         "report_files": list_report_files(report_dir) if report_dir else [],
@@ -74,7 +76,14 @@ def _render_overview(result: dict[str, Any] | None) -> None:
         st.caption(f"Output directory: {result['output_dir']}")
 
     if result.get("error"):
-        st.warning(result["error"])
+        st.error(result["error"])
+        with st.expander("Error details"):
+            if result.get("error_type"):
+                st.write(f"Type: `{result['error_type']}`")
+            if result.get("traceback"):
+                st.code(result["traceback"], language="python")
+            else:
+                st.write("No additional debug details are available.")
 
     col1, col2, col3 = st.columns(3)
     with col1:

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -30,6 +30,8 @@ from marketflow.services.report_index import (
 
 DEFAULT_TIMEFRAMES = ["1d", "4h", "1h"]
 TIMEFRAME_OPTIONS = ["1mo", "1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m"]
+CSV_PREVIEW_ROW_OPTIONS = [100, 250, 500, 1000]
+CHART_ROW_OPTIONS = [200, 500, 1000, 2000]
 
 
 def _load_latest_result(ticker: str) -> dict[str, Any]:
@@ -43,7 +45,7 @@ def _load_latest_result(ticker: str) -> dict[str, Any]:
         "narrative": summary_text or "",
         "output_dir": report_dir,
         "success": bool(report_dir),
-        "error": None if report_dir else f"No report found for {ticker}.",
+        "error": None if report_dir else f"No report found for {ticker}. Run an analysis first.",
         "error_type": None,
         "traceback": None,
         "report_json": report_json,
@@ -68,10 +70,92 @@ def _display_value(label: str, value: Any) -> None:
         st.metric(label, value)
 
 
+def _render_error_details(result: dict[str, Any]) -> None:
+    """Render a compact error message with debug details hidden by default."""
+    if not result.get("error"):
+        return
+
+    error_type = result.get("error_type")
+    if error_type:
+        st.error(f"{error_type}: {result['error']}")
+    else:
+        st.error(result["error"])
+
+    with st.expander("Error details"):
+        if error_type:
+            st.write(f"Type: `{error_type}`")
+        if result.get("traceback"):
+            st.code(result["traceback"], language="python")
+        else:
+            st.write("No traceback is available.")
+
+
+def _report_dir_from_result(
+    result: dict[str, Any] | None,
+    empty_message: str,
+) -> str | None:
+    """Return the loaded report directory or render a friendly empty/error state."""
+    if not result or not result.get("output_dir"):
+        st.info(empty_message)
+        return None
+
+    report_dir = result["output_dir"]
+    report_path = Path(report_dir)
+    if not report_path.exists() or not report_path.is_dir():
+        st.warning(f"Report directory does not exist: {report_dir}")
+        return None
+
+    return report_dir
+
+
+def _render_loaded_report_caption(result: dict[str, Any] | None) -> None:
+    """Show the currently loaded ticker and report directory when available."""
+    if not result:
+        st.caption("No report loaded. Use Run Analysis or Load Latest Report.")
+        return
+
+    ticker = result.get("ticker") or "unknown ticker"
+    if result.get("output_dir"):
+        st.caption(f"Loaded: `{ticker}` | `{result['output_dir']}`")
+    elif result.get("error"):
+        st.caption(f"No loaded report for {ticker}.")
+
+
+def _annotated_csv_files_for_report(report_dir: str) -> list[str]:
+    """Return annotated CSV files for a loaded report directory."""
+    return list_annotated_csv_files(report_dir)
+
+
+def _select_annotated_csv(
+    csv_files: list[str],
+    label: str,
+    key: str,
+) -> str:
+    """Render a CSV selector using filenames as labels."""
+    return st.selectbox(
+        label,
+        options=csv_files,
+        format_func=lambda path: Path(path).name,
+        key=key,
+    )
+
+
+def _render_csv_file_context(csv_path: str) -> str | None:
+    """Display selected CSV metadata shared by preview and chart tabs."""
+    timeframe = infer_timeframe_from_csv_name(csv_path)
+    st.write(f"Filename: `{Path(csv_path).name}`")
+    if timeframe:
+        st.write(f"Timeframe: `{timeframe}`")
+    else:
+        st.caption("Timeframe could not be inferred from the filename.")
+    return timeframe
+
+
 def _render_overview(result: dict[str, Any] | None) -> None:
     """Render the Overview tab."""
     if not result:
         st.info("Run an analysis or load the latest report to view an overview.")
+        st.caption("Reports are loaded from the configured `.marketflow/reports` directory.")
         return
 
     report_json = result.get("report_json") or {}
@@ -80,17 +164,12 @@ def _render_overview(result: dict[str, Any] | None) -> None:
 
     st.subheader(result.get("ticker") or "Ticker")
     if result.get("output_dir"):
-        st.caption(f"Output directory: {result['output_dir']}")
+        st.caption(f"Output directory: `{result['output_dir']}`")
 
     if result.get("error"):
-        st.error(result["error"])
-        with st.expander("Error details"):
-            if result.get("error_type"):
-                st.write(f"Type: `{result['error_type']}`")
-            if result.get("traceback"):
-                st.code(result["traceback"], language="python")
-            else:
-                st.write("No additional debug details are available.")
+        _render_error_details(result)
+        if not report_json:
+            return
 
     col1, col2, col3 = st.columns(3)
     with col1:
@@ -116,11 +195,13 @@ def _render_overview(result: dict[str, Any] | None) -> None:
 
 def _render_reports(result: dict[str, Any] | None) -> None:
     """Render the Reports tab."""
-    if not result or not result.get("output_dir"):
-        st.info("No report directory loaded.")
+    report_dir = _report_dir_from_result(
+        result,
+        "No report directory loaded. Run an analysis or load the latest report first.",
+    )
+    if not report_dir:
         return
 
-    report_dir = result["output_dir"]
     st.write(f"Report directory: `{report_dir}`")
 
     files = list_report_files(report_dir) or result.get("report_files") or []
@@ -151,40 +232,28 @@ def _render_reports(result: dict[str, Any] | None) -> None:
 
 def _render_csv_preview(result: dict[str, Any] | None) -> None:
     """Render the CSV Preview tab."""
-    if not result or not result.get("output_dir"):
-        st.info("Load a report or run an analysis before previewing CSV files.")
+    report_dir = _report_dir_from_result(
+        result,
+        "Load a report or run an analysis before previewing CSV files.",
+    )
+    if not report_dir:
         return
 
-    report_dir = result["output_dir"]
-    report_path = Path(report_dir)
-    if not report_path.exists() or not report_path.is_dir():
-        st.warning(f"Report directory does not exist: {report_dir}")
-        return
-
-    csv_files = list_annotated_csv_files(report_dir)
+    csv_files = _annotated_csv_files_for_report(report_dir)
     if not csv_files:
         st.info("No annotated CSV files found in this report directory.")
+        st.caption("Run Analysis with timeframes that generate Wyckoff annotated exports.")
         return
 
-    selected_csv = st.selectbox(
-        "CSV file",
-        options=csv_files,
-        format_func=lambda path: Path(path).name,
-        key="csv_preview_file",
-    )
+    selected_csv = _select_annotated_csv(csv_files, "CSV file", "csv_preview_file")
     preview_rows = st.selectbox(
         "Preview rows",
-        options=[100, 250, 500, 1000],
+        options=CSV_PREVIEW_ROW_OPTIONS,
         index=2,
         key="csv_preview_rows",
     )
 
-    timeframe = infer_timeframe_from_csv_name(selected_csv)
-    st.write(f"Filename: `{Path(selected_csv).name}`")
-    if timeframe:
-        st.write(f"Timeframe: `{timeframe}`")
-    else:
-        st.write("Timeframe: unknown")
+    _render_csv_file_context(selected_csv)
 
     dataframe = load_csv_preview(selected_csv, nrows=preview_rows)
     if dataframe is None:
@@ -201,40 +270,25 @@ def _render_csv_preview(result: dict[str, Any] | None) -> None:
 
 def _render_charts(result: dict[str, Any] | None) -> None:
     """Render the Charts tab."""
-    if not result or not result.get("output_dir"):
-        st.info("Run an analysis or load a report first.")
+    report_dir = _report_dir_from_result(result, "Run an analysis or load a report first.")
+    if not report_dir:
         return
 
-    report_dir = result["output_dir"]
-    report_path = Path(report_dir)
-    if not report_path.exists() or not report_path.is_dir():
-        st.warning(f"Report directory does not exist: {report_dir}")
-        return
-
-    csv_files = list_annotated_csv_files(report_dir)
+    csv_files = _annotated_csv_files_for_report(report_dir)
     if not csv_files:
         st.info("No annotated CSV files found for charting.")
+        st.caption("Charts use annotated OHLC CSV files generated by MarketFlow reports.")
         return
 
-    selected_csv = st.selectbox(
-        "Chart CSV file",
-        options=csv_files,
-        format_func=lambda path: Path(path).name,
-        key="chart_csv_file",
-    )
+    selected_csv = _select_annotated_csv(csv_files, "Chart CSV file", "chart_csv_file")
     chart_rows = st.selectbox(
         "Chart rows",
-        options=[200, 500, 1000, 2000],
+        options=CHART_ROW_OPTIONS,
         index=1,
         key="chart_rows",
     )
 
-    timeframe = infer_timeframe_from_csv_name(selected_csv)
-    st.write(f"Filename: `{Path(selected_csv).name}`")
-    if timeframe:
-        st.write(f"Timeframe: `{timeframe}`")
-    else:
-        st.write("Timeframe: unknown")
+    timeframe = _render_csv_file_context(selected_csv)
 
     dataframe = load_csv_for_chart(selected_csv, nrows=chart_rows)
     if dataframe is None:
@@ -289,6 +343,8 @@ def main() -> None:
 
         if st.button("Load Latest Report"):
             st.session_state.analysis_result = _load_latest_result(ticker)
+
+        _render_loaded_report_caption(st.session_state.analysis_result)
 
     result = st.session_state.analysis_result
     overview_tab, reports_tab, csv_tab, charts_tab, raw_json_tab = st.tabs(

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -26,12 +26,19 @@ from marketflow.services.report_index import (
     load_report_json,
     load_summary_text,
 )
+from marketflow.services.strategy_service import (
+    get_report_root,
+    normalize_tickers,
+    rank_latest_candidates,
+)
 
 
 DEFAULT_TIMEFRAMES = ["1d", "4h", "1h"]
 TIMEFRAME_OPTIONS = ["1mo", "1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m"]
 CSV_PREVIEW_ROW_OPTIONS = [100, 250, 500, 1000]
 CHART_ROW_OPTIONS = [200, 500, 1000, 2000]
+STRATEGY_TIMEFRAMES = ["1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m"]
+WYCKOFF_PHASE_OPTIONS = ["A", "B", "C", "D", "E", "UNKNOWN"]
 
 
 def _load_latest_result(ticker: str) -> dict[str, Any]:
@@ -311,6 +318,135 @@ def _render_charts(result: dict[str, Any] | None) -> None:
             st.code(str(exc))
 
 
+def _default_strategy_ticker_text(result: dict[str, Any] | None) -> str:
+    """Return the currently loaded ticker as the strategy ticker default."""
+    if result and result.get("ticker"):
+        return str(result["ticker"])
+    return "AAPL"
+
+
+def _render_strategy_error(strategy_result: dict[str, Any]) -> None:
+    """Render strategy ranking errors with traceback hidden by default."""
+    error_type = strategy_result.get("error_type")
+    error_message = strategy_result.get("error") or "Strategy ranking failed."
+    if error_type:
+        st.error(f"{error_type}: {error_message}")
+    else:
+        st.error(error_message)
+
+    if strategy_result.get("traceback"):
+        with st.expander("Strategy error details"):
+            st.code(strategy_result["traceback"], language="python")
+
+
+def _render_strategy_results(strategy_result: dict[str, Any] | None) -> None:
+    """Render strategy ranking output."""
+    if not strategy_result:
+        st.info("Choose tickers and click Rank Candidates to scan existing reports.")
+        return
+
+    st.caption(f"Using report root: `{strategy_result.get('report_root')}`")
+    st.caption("Strategy source: latest batch folder when available")
+    st.caption(f"Selected timeframe: `{strategy_result.get('timeframe')}`")
+
+    if not strategy_result.get("success"):
+        _render_strategy_error(strategy_result)
+        return
+
+    dataframe = strategy_result.get("dataframe")
+    if dataframe is None or dataframe.empty:
+        st.info(
+            "No candidates passed the filters. Try a lower min RR, a different timeframe, "
+            "or confirm reports exist for those tickers."
+        )
+        return
+
+    st.write(f"Result count: `{len(dataframe)}`")
+    st.dataframe(dataframe, use_container_width=True)
+
+    results = strategy_result.get("results") or []
+    labels = [
+        f"{candidate.get('ticker', 'UNKNOWN')} | {candidate.get('tf', '')} | "
+        f"score {candidate.get('score', 'NA')}"
+        for candidate in results
+    ]
+    selected_label = st.selectbox("Select candidate", options=labels)
+    selected_index = labels.index(selected_label)
+    st.json(results[selected_index])
+
+
+def _render_strategy_ranking(result: dict[str, Any] | None) -> None:
+    """Render the Strategy Ranking tab."""
+    st.write(
+        "Rank long candidates from generated MarketFlow reports using the existing "
+        "`marketflow_strategy` logic."
+    )
+    st.caption(f"Configured report root: `{get_report_root()}`")
+    st.caption("This scan uses the latest batch/report namespace when available.")
+
+    if "strategy_tickers" not in st.session_state:
+        st.session_state.strategy_tickers = _default_strategy_ticker_text(result)
+
+    ticker_text = st.text_area(
+        "Tickers",
+        key="strategy_tickers",
+        help="Enter tickers separated by spaces, commas, or new lines.",
+    )
+    strategy_tf = st.selectbox(
+        "Timeframe",
+        options=STRATEGY_TIMEFRAMES,
+        index=1,
+    )
+    min_rr = st.number_input(
+        "Minimum Risk/Reward",
+        min_value=0.1,
+        value=1.5,
+        step=0.1,
+    )
+    max_sl_atr = st.number_input(
+        "Max Stop ATR",
+        min_value=0.1,
+        value=2.0,
+        step=0.1,
+    )
+    prefer_phases = st.multiselect(
+        "Preferred Wyckoff Phases",
+        options=WYCKOFF_PHASE_OPTIONS,
+        default=["C", "D", "E"],
+    )
+    use_mc = st.checkbox(
+        "Use Monte Carlo POP if available",
+        value=False,
+        help="Optional. If no MC files exist, strategy logic should use neutral defaults.",
+    )
+
+    if st.button("Rank Candidates"):
+        tickers = normalize_tickers(ticker_text)
+        if not tickers:
+            st.session_state.strategy_result = {
+                "success": False,
+                "error": "Enter at least one ticker.",
+                "error_type": "ValidationError",
+                "traceback": None,
+                "results": [],
+                "dataframe": None,
+                "report_root": get_report_root(),
+                "timeframe": strategy_tf,
+            }
+        else:
+            with st.spinner("Ranking strategy candidates..."):
+                st.session_state.strategy_result = rank_latest_candidates(
+                    tickers=tickers,
+                    timeframe=strategy_tf,
+                    min_rr=float(min_rr),
+                    max_sl_atr=float(max_sl_atr),
+                    prefer_phases=tuple(prefer_phases),
+                    use_mc=use_mc,
+                )
+
+    _render_strategy_results(st.session_state.get("strategy_result"))
+
+
 def _render_raw_json(result: dict[str, Any] | None) -> None:
     """Render the Raw JSON tab."""
     report_json = result.get("report_json") if result else None
@@ -327,6 +463,8 @@ def main() -> None:
 
     if "analysis_result" not in st.session_state:
         st.session_state.analysis_result = None
+    if "strategy_result" not in st.session_state:
+        st.session_state.strategy_result = None
 
     with st.sidebar:
         st.header("Analysis")
@@ -347,8 +485,8 @@ def main() -> None:
         _render_loaded_report_caption(st.session_state.analysis_result)
 
     result = st.session_state.analysis_result
-    overview_tab, reports_tab, csv_tab, charts_tab, raw_json_tab = st.tabs(
-        ["Overview", "Reports", "CSV Preview", "Charts", "Raw JSON"]
+    overview_tab, reports_tab, csv_tab, charts_tab, strategy_tab, raw_json_tab = st.tabs(
+        ["Overview", "Reports", "CSV Preview", "Charts", "Strategy Ranking", "Raw JSON"]
     )
 
     with overview_tab:
@@ -362,6 +500,9 @@ def main() -> None:
 
     with charts_tab:
         _render_charts(result)
+
+    with strategy_tab:
+        _render_strategy_ranking(result)
 
     with raw_json_tab:
         _render_raw_json(result)

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -14,6 +14,10 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from marketflow.charts.wyckoff_chart import build_basic_wyckoff_candlestick_chart
 from marketflow.services.analysis_service import run_single_ticker
+from marketflow.services.monte_carlo_service import (
+    load_latest_close,
+    run_monte_carlo_for_csv,
+)
 from marketflow.services.report_index import (
     find_latest_ticker_report,
     infer_timeframe_from_csv_name,
@@ -39,6 +43,7 @@ CSV_PREVIEW_ROW_OPTIONS = [100, 250, 500, 1000]
 CHART_ROW_OPTIONS = [200, 500, 1000, 2000]
 STRATEGY_TIMEFRAMES = ["1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m"]
 WYCKOFF_PHASE_OPTIONS = ["A", "B", "C", "D", "E", "UNKNOWN"]
+MONTE_CARLO_MODELS = ["bootstrap", "gbm", "garch"]
 
 
 def _load_latest_result(ticker: str) -> dict[str, Any]:
@@ -74,6 +79,34 @@ def _nested_get(data: dict[str, Any] | None, keys: list[str]) -> Any:
 def _display_value(label: str, value: Any) -> None:
     """Display a scalar value if it is available."""
     if value is not None and value != "":
+        st.metric(label, value)
+
+
+def _format_probability(value: Any) -> str | None:
+    """Format a probability-like value for display."""
+    if value is None:
+        return None
+    try:
+        return f"{float(value) * 100:.1f}%"
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_number(value: Any, decimals: int = 4) -> str | None:
+    """Format a numeric value for compact metric display."""
+    if value is None:
+        return None
+    try:
+        return f"{float(value):.{decimals}f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _display_optional_metric(label: str, value: Any) -> None:
+    """Display a metric when available, otherwise show a muted missing value."""
+    if value is None or value == "":
+        st.caption(f"{label}: not available")
+    else:
         st.metric(label, value)
 
 
@@ -514,6 +547,170 @@ def _render_strategy_ranking(result: dict[str, Any] | None) -> None:
     _render_strategy_results(st.session_state.get("strategy_result"))
 
 
+def _default_trade_levels(latest_close: float | None) -> tuple[float, float, float]:
+    """Return sensible entry, stop, and take-profit defaults."""
+    if latest_close is None or latest_close <= 0:
+        return 0.0, 0.0, 0.0
+    return latest_close, latest_close * 0.98, latest_close * 1.05
+
+
+def _render_monte_carlo_error(monte_carlo_result: dict[str, Any]) -> None:
+    """Render Monte Carlo service errors with traceback hidden by default."""
+    error_type = monte_carlo_result.get("error_type")
+    error_message = monte_carlo_result.get("error") or "Monte Carlo simulation failed."
+    if error_type:
+        st.error(f"{error_type}: {error_message}")
+    else:
+        st.error(error_message)
+
+    if monte_carlo_result.get("traceback"):
+        with st.expander("Monte Carlo error details"):
+            st.code(monte_carlo_result["traceback"], language="python")
+
+
+def _render_monte_carlo_results(monte_carlo_result: dict[str, Any] | None) -> None:
+    """Render Monte Carlo output metrics and raw result data."""
+    if not monte_carlo_result:
+        st.info("Select a CSV and click Run Monte Carlo to simulate a single trade.")
+        return
+
+    if not monte_carlo_result.get("success"):
+        _render_monte_carlo_error(monte_carlo_result)
+        return
+
+    result = monte_carlo_result.get("result") or {}
+    params = result.get("params") or {}
+    metrics = result.get("metrics_from_entry") or result.get("metrics_from_now") or {}
+
+    st.success("Monte Carlo simulation completed.")
+    st.caption(f"CSV: `{Path(monte_carlo_result.get('csv_path') or '').name}`")
+
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        _display_optional_metric("Model", params.get("model"))
+        _display_optional_metric("Entry", _format_number(params.get("entry")))
+    with col2:
+        _display_optional_metric("Stop Loss", _format_number(params.get("sl")))
+        _display_optional_metric("Take Profit", _format_number(params.get("tp")))
+    with col3:
+        _display_optional_metric("Spot S0", _format_number(_nested_get(result, ["spot", "S0_now"])))
+        _display_optional_metric(
+            "Calibration Model",
+            _nested_get(result, ["calibration", "model_used"]),
+        )
+    with col4:
+        _display_optional_metric("TP First", _format_probability(metrics.get("pop_tp_first")))
+        _display_optional_metric("SL First", _format_probability(metrics.get("p_sl_first")))
+
+    col5, col6 = st.columns(2)
+    with col5:
+        _display_optional_metric("Median Bars to TP", metrics.get("t_hit_tp_median"))
+    with col6:
+        _display_optional_metric("Median Bars to SL", metrics.get("t_hit_sl_median"))
+
+    st.info("Monte Carlo JSON/HTML outputs were saved next to the selected CSV by the existing simulator.")
+    with st.expander("Raw Monte Carlo result"):
+        st.json(result)
+
+
+def _render_monte_carlo(result: dict[str, Any] | None) -> None:
+    """Render the Monte Carlo tab."""
+    report_dir = _report_dir_from_result(result, "Run an analysis or load a report first.")
+    if not report_dir:
+        return
+
+    csv_files = _annotated_csv_files_for_report(report_dir)
+    if not csv_files:
+        st.info("No annotated CSV files found for Monte Carlo simulation.")
+        st.caption("Run Analysis first, then return here to select a generated OHLC CSV.")
+        return
+
+    selected_csv = _select_annotated_csv(csv_files, "Monte Carlo CSV file", "monte_carlo_csv_file")
+    timeframe = _render_csv_file_context(selected_csv)
+    latest_close = load_latest_close(selected_csv)
+    if latest_close is not None:
+        st.caption(f"Latest close loaded from CSV: `{latest_close:.4f}`")
+    else:
+        st.warning("Could not load the latest close from this CSV. Enter trade levels manually.")
+
+    default_entry, default_stop, default_take = _default_trade_levels(latest_close)
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        entry = st.number_input(
+            "Entry",
+            min_value=0.0,
+            value=float(default_entry),
+            step=0.01,
+            format="%.4f",
+        )
+    with col2:
+        stop_loss = st.number_input(
+            "Stop Loss",
+            min_value=0.0,
+            value=float(default_stop),
+            step=0.01,
+            format="%.4f",
+        )
+    with col3:
+        take_profit = st.number_input(
+            "Take Profit",
+            min_value=0.0,
+            value=float(default_take),
+            step=0.01,
+            format="%.4f",
+        )
+
+    col4, col5, col6, col7 = st.columns(4)
+    with col4:
+        model = st.selectbox("Model", options=MONTE_CARLO_MODELS, index=0)
+    with col5:
+        paths = st.number_input("Paths", min_value=1000, max_value=50000, value=10000, step=1000)
+    with col6:
+        horizon = st.number_input("Horizon", min_value=1, max_value=250, value=20, step=1)
+    with col7:
+        block_len = st.number_input("Block Length", min_value=1, max_value=100, value=8, step=1)
+
+    seed = st.number_input("Seed", value=42, step=1)
+    save_plots = st.checkbox("Save plots", value=True)
+
+    if st.button("Run Monte Carlo"):
+        validation_errors = []
+        if not Path(selected_csv).exists():
+            validation_errors.append("Selected CSV file does not exist.")
+        if entry <= 0:
+            validation_errors.append("Entry must be greater than zero.")
+        if stop_loss >= entry:
+            validation_errors.append("Stop loss must be below entry.")
+        if take_profit <= entry:
+            validation_errors.append("Take profit must be above entry.")
+        if paths <= 0:
+            validation_errors.append("Paths must be positive.")
+        if horizon <= 0:
+            validation_errors.append("Horizon must be positive.")
+
+        if validation_errors:
+            for message in validation_errors:
+                st.warning(message)
+        else:
+            with st.spinner("Running Monte Carlo simulation..."):
+                st.session_state.monte_carlo_result = run_monte_carlo_for_csv(
+                    csv_path=selected_csv,
+                    entry=float(entry),
+                    stop_loss=float(stop_loss),
+                    take_profit=float(take_profit),
+                    timeframe=timeframe,
+                    model=model,
+                    paths=int(paths),
+                    horizon=int(horizon),
+                    block_len=int(block_len),
+                    seed=int(seed),
+                    save_plots=save_plots,
+                )
+
+    _render_monte_carlo_results(st.session_state.get("monte_carlo_result"))
+
+
 def _render_raw_json(result: dict[str, Any] | None) -> None:
     """Render the Raw JSON tab."""
     report_json = result.get("report_json") if result else None
@@ -532,6 +729,8 @@ def main() -> None:
         st.session_state.analysis_result = None
     if "strategy_result" not in st.session_state:
         st.session_state.strategy_result = None
+    if "monte_carlo_result" not in st.session_state:
+        st.session_state.monte_carlo_result = None
 
     with st.sidebar:
         st.header("Analysis")
@@ -552,8 +751,24 @@ def main() -> None:
         _render_loaded_report_caption(st.session_state.analysis_result)
 
     result = st.session_state.analysis_result
-    overview_tab, reports_tab, csv_tab, charts_tab, strategy_tab, raw_json_tab = st.tabs(
-        ["Overview", "Reports", "CSV Preview", "Charts", "Strategy Ranking", "Raw JSON"]
+    (
+        overview_tab,
+        reports_tab,
+        csv_tab,
+        charts_tab,
+        strategy_tab,
+        monte_carlo_tab,
+        raw_json_tab,
+    ) = st.tabs(
+        [
+            "Overview",
+            "Reports",
+            "CSV Preview",
+            "Charts",
+            "Strategy Ranking",
+            "Monte Carlo",
+            "Raw JSON",
+        ]
     )
 
     with overview_tab:
@@ -570,6 +785,9 @@ def main() -> None:
 
     with strategy_tab:
         _render_strategy_ranking(result)
+
+    with monte_carlo_tab:
+        _render_monte_carlo(result)
 
     with raw_json_tab:
         _render_raw_json(result)

--- a/apps/marketflow_studio.py
+++ b/apps/marketflow_studio.py
@@ -12,6 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from marketflow.charts.wyckoff_chart import build_basic_wyckoff_candlestick_chart
 from marketflow.services.analysis_service import run_single_ticker
 from marketflow.services.report_index import (
     find_latest_ticker_report,
@@ -20,6 +21,7 @@ from marketflow.services.report_index import (
     list_available_tickers,
     list_report_date_folders,
     list_report_files,
+    load_csv_for_chart,
     load_csv_preview,
     load_report_json,
     load_summary_text,
@@ -168,8 +170,14 @@ def _render_csv_preview(result: dict[str, Any] | None) -> None:
         "CSV file",
         options=csv_files,
         format_func=lambda path: Path(path).name,
+        key="csv_preview_file",
     )
-    preview_rows = st.selectbox("Preview rows", options=[100, 250, 500, 1000], index=2)
+    preview_rows = st.selectbox(
+        "Preview rows",
+        options=[100, 250, 500, 1000],
+        index=2,
+        key="csv_preview_rows",
+    )
 
     timeframe = infer_timeframe_from_csv_name(selected_csv)
     st.write(f"Filename: `{Path(selected_csv).name}`")
@@ -189,6 +197,64 @@ def _render_csv_preview(result: dict[str, Any] | None) -> None:
     st.write(", ".join(f"`{column}`" for column in dataframe.columns))
 
     st.dataframe(dataframe, use_container_width=True)
+
+
+def _render_charts(result: dict[str, Any] | None) -> None:
+    """Render the Charts tab."""
+    if not result or not result.get("output_dir"):
+        st.info("Run an analysis or load a report first.")
+        return
+
+    report_dir = result["output_dir"]
+    report_path = Path(report_dir)
+    if not report_path.exists() or not report_path.is_dir():
+        st.warning(f"Report directory does not exist: {report_dir}")
+        return
+
+    csv_files = list_annotated_csv_files(report_dir)
+    if not csv_files:
+        st.info("No annotated CSV files found for charting.")
+        return
+
+    selected_csv = st.selectbox(
+        "Chart CSV file",
+        options=csv_files,
+        format_func=lambda path: Path(path).name,
+        key="chart_csv_file",
+    )
+    chart_rows = st.selectbox(
+        "Chart rows",
+        options=[200, 500, 1000, 2000],
+        index=1,
+        key="chart_rows",
+    )
+
+    timeframe = infer_timeframe_from_csv_name(selected_csv)
+    st.write(f"Filename: `{Path(selected_csv).name}`")
+    if timeframe:
+        st.write(f"Timeframe: `{timeframe}`")
+    else:
+        st.write("Timeframe: unknown")
+
+    dataframe = load_csv_for_chart(selected_csv, nrows=chart_rows)
+    if dataframe is None:
+        st.error("Could not load this CSV file for charting.")
+        return
+
+    try:
+        title_parts = [Path(selected_csv).stem]
+        if timeframe:
+            title_parts.append(timeframe)
+        fig = build_basic_wyckoff_candlestick_chart(
+            dataframe,
+            title=" - ".join(title_parts),
+        )
+        st.plotly_chart(fig, use_container_width=True)
+    except Exception as exc:
+        st.error("Could not build chart.")
+        with st.expander("Chart error details"):
+            st.write(f"Type: `{type(exc).__name__}`")
+            st.code(str(exc))
 
 
 def _render_raw_json(result: dict[str, Any] | None) -> None:
@@ -225,8 +291,8 @@ def main() -> None:
             st.session_state.analysis_result = _load_latest_result(ticker)
 
     result = st.session_state.analysis_result
-    overview_tab, reports_tab, csv_tab, raw_json_tab = st.tabs(
-        ["Overview", "Reports", "CSV Preview", "Raw JSON"]
+    overview_tab, reports_tab, csv_tab, charts_tab, raw_json_tab = st.tabs(
+        ["Overview", "Reports", "CSV Preview", "Charts", "Raw JSON"]
     )
 
     with overview_tab:
@@ -237,6 +303,9 @@ def main() -> None:
 
     with csv_tab:
         _render_csv_preview(result)
+
+    with charts_tab:
+        _render_charts(result)
 
     with raw_json_tab:
         _render_raw_json(result)

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -99,7 +99,8 @@ streamlit run apps/marketflow_studio.py
 - Milestone 4: Strategy Ranking tab - implemented on `feature/personal-ui-milestone-1`
 - Strategy Ranking diagnostics - implemented
 - Strategy latest-batch diagnostics refinement - implemented
-- Next planned milestone: Monte Carlo tab
+- Monte Carlo tab, simple single-run mode - implemented
+- Next planned milestone: Wyckoff Volume Analyst
 
 ---
 

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -97,6 +97,7 @@ streamlit run apps/marketflow_studio.py
 - Milestone 2: Report Browser and CSV Preview - implemented
 - Milestone 3: Basic Chart Tab - implemented
 - Milestone 4: Strategy Ranking tab - implemented on `feature/personal-ui-milestone-1`
+- Strategy Ranking diagnostics - implemented
 - Next planned milestone: Monte Carlo tab
 
 ---

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -98,6 +98,7 @@ streamlit run apps/marketflow_studio.py
 - Milestone 3: Basic Chart Tab - implemented
 - Milestone 4: Strategy Ranking tab - implemented on `feature/personal-ui-milestone-1`
 - Strategy Ranking diagnostics - implemented
+- Strategy latest-batch diagnostics refinement - implemented
 - Next planned milestone: Monte Carlo tab
 
 ---

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -93,14 +93,15 @@ streamlit run apps/marketflow_studio.py
 
 ## Implementation Progress
 
-- Milestone 1: Initial Streamlit UI - implemented on `feature/personal-ui-milestone-1`
-- Milestone 2: Report Browser and CSV Preview - implemented
-- Milestone 3: Basic Chart Tab - implemented
-- Milestone 4: Strategy Ranking tab - implemented on `feature/personal-ui-milestone-1`
-- Strategy Ranking diagnostics - implemented
-- Strategy latest-batch diagnostics refinement - implemented
-- Monte Carlo tab, simple single-run mode - implemented
-- Next planned milestone: Wyckoff Volume Analyst
+- Milestone 1: Initial Streamlit UI — implemented
+- Timeframe normalization fix — implemented
+- Milestone 2: Report Browser and CSV Preview — implemented
+- Milestone 3: Basic Chart Tab — implemented
+- Milestone 4: Strategy Ranking tab — implemented
+- Strategy Ranking diagnostics — implemented
+- Strategy latest-batch diagnostics refinement — implemented
+- Monte Carlo tab, simple single-run mode — implemented
+- Next planned milestone: PR review / merge to main
 
 ---
 

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -96,7 +96,8 @@ streamlit run apps/marketflow_studio.py
 - Milestone 1: Initial Streamlit UI - implemented on `feature/personal-ui-milestone-1`
 - Milestone 2: Report Browser and CSV Preview - implemented
 - Milestone 3: Basic Chart Tab - implemented
-- Next planned milestone: Strategy Ranking tab
+- Milestone 4: Strategy Ranking tab - implemented on `feature/personal-ui-milestone-1`
+- Next planned milestone: Monte Carlo tab
 
 ---
 

--- a/markdown_files/marketflow_personal_ui_plan.md
+++ b/markdown_files/marketflow_personal_ui_plan.md
@@ -91,6 +91,15 @@ streamlit run apps/marketflow_studio.py
 
 ---
 
+## Implementation Progress
+
+- Milestone 1: Initial Streamlit UI - implemented on `feature/personal-ui-milestone-1`
+- Milestone 2: Report Browser and CSV Preview - implemented
+- Milestone 3: Basic Chart Tab - implemented
+- Next planned milestone: Strategy Ranking tab
+
+---
+
 ## Non-Goals
 
 Do not build these in the first version:

--- a/marketflow/charts/__init__.py
+++ b/marketflow/charts/__init__.py
@@ -1,0 +1,2 @@
+"""Chart builders for MarketFlow UI surfaces."""
+

--- a/marketflow/charts/wyckoff_chart.py
+++ b/marketflow/charts/wyckoff_chart.py
@@ -15,8 +15,10 @@ REQUIRED_OHLC_COLUMNS = ("open", "high", "low", "close")
 def _chart_x_values(df: pd.DataFrame) -> pd.Series | pd.Index:
     """Return datetime x-values from timestamp column or DataFrame index."""
     if "timestamp" in df.columns:
-        return pd.to_datetime(df["timestamp"], errors="coerce")
-    return pd.to_datetime(df.index, errors="coerce")
+        timestamps = pd.to_datetime(df["timestamp"], errors="coerce")
+        if timestamps.notna().any():
+            return timestamps
+    return df.index
 
 
 def _latest_numeric_value(df: pd.DataFrame, column: str) -> float | None:
@@ -183,4 +185,3 @@ def build_basic_wyckoff_candlestick_chart(
         fig.update_yaxes(title_text="Volume", row=2, col=1)
 
     return fig
-

--- a/marketflow/charts/wyckoff_chart.py
+++ b/marketflow/charts/wyckoff_chart.py
@@ -1,0 +1,186 @@
+"""Basic Plotly chart builders for annotated MarketFlow CSV data."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+
+REQUIRED_OHLC_COLUMNS = ("open", "high", "low", "close")
+
+
+def _chart_x_values(df: pd.DataFrame) -> pd.Series | pd.Index:
+    """Return datetime x-values from timestamp column or DataFrame index."""
+    if "timestamp" in df.columns:
+        return pd.to_datetime(df["timestamp"], errors="coerce")
+    return pd.to_datetime(df.index, errors="coerce")
+
+
+def _latest_numeric_value(df: pd.DataFrame, column: str) -> float | None:
+    """Return the latest numeric value from a column, ignoring missing values."""
+    if column not in df.columns:
+        return None
+
+    values = pd.to_numeric(df[column], errors="coerce").dropna()
+    if values.empty:
+        return None
+    return float(values.iloc[-1])
+
+
+def _event_points(df: pd.DataFrame, column: str, x_values: Any) -> pd.DataFrame:
+    """Return rows with non-empty event labels for marker rendering."""
+    if column not in df.columns:
+        return pd.DataFrame()
+
+    event_series = df[column].fillna("").astype(str).str.strip()
+    event_series = event_series[event_series.ne("") & event_series.ne("nan")]
+    if event_series.empty:
+        return pd.DataFrame()
+
+    event_df = df.loc[event_series.index, ["high", "low"]].copy()
+    event_df["event_label"] = event_series
+    event_df["x"] = pd.Series(x_values, index=df.index).loc[event_series.index]
+    return event_df
+
+
+def build_basic_wyckoff_candlestick_chart(
+    df: pd.DataFrame,
+    title: str | None = None,
+) -> go.Figure:
+    """
+    Build a basic Plotly candlestick chart from an annotated MarketFlow CSV.
+
+    Expected columns:
+    - timestamp, or a datetime-like index
+    - open
+    - high
+    - low
+    - close
+    - volume, optional
+
+    Optional annotation columns:
+    - wyckoff_phase
+    - wyckoff_event
+    - wyckoff_confirmed_event
+    - tr_low
+    - tr_high
+    """
+    if df is None or df.empty:
+        raise ValueError("CSV data is empty.")
+
+    missing_columns = [column for column in REQUIRED_OHLC_COLUMNS if column not in df.columns]
+    if missing_columns:
+        missing = ", ".join(missing_columns)
+        raise ValueError(f"Missing required OHLC column(s): {missing}.")
+
+    chart_df = df.copy()
+    x_values = _chart_x_values(chart_df)
+
+    for column in [*REQUIRED_OHLC_COLUMNS, "volume", "tr_low", "tr_high"]:
+        if column in chart_df.columns:
+            chart_df[column] = pd.to_numeric(chart_df[column], errors="coerce")
+
+    chart_df = chart_df.dropna(subset=list(REQUIRED_OHLC_COLUMNS))
+    if chart_df.empty:
+        raise ValueError("CSV data has no valid OHLC rows.")
+
+    x_values = pd.Series(x_values, index=df.index).loc[chart_df.index]
+    has_volume = "volume" in chart_df.columns and chart_df["volume"].notna().any()
+    row_count = 2 if has_volume else 1
+    row_heights = [0.72, 0.28] if has_volume else [1.0]
+
+    fig = make_subplots(
+        rows=row_count,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.04,
+        row_heights=row_heights,
+    )
+
+    fig.add_trace(
+        go.Candlestick(
+            x=x_values,
+            open=chart_df["open"],
+            high=chart_df["high"],
+            low=chart_df["low"],
+            close=chart_df["close"],
+            name="OHLC",
+        ),
+        row=1,
+        col=1,
+    )
+
+    if has_volume:
+        fig.add_trace(
+            go.Bar(
+                x=x_values,
+                y=chart_df["volume"],
+                name="Volume",
+                marker_color="rgba(86, 118, 160, 0.45)",
+            ),
+            row=2,
+            col=1,
+        )
+
+    tr_low = _latest_numeric_value(chart_df, "tr_low")
+    if tr_low is not None:
+        fig.add_hline(
+            y=tr_low,
+            line_dash="dash",
+            line_color="#2ca02c",
+            annotation_text="TR low",
+            annotation_position="bottom right",
+            row=1,
+            col=1,
+        )
+
+    tr_high = _latest_numeric_value(chart_df, "tr_high")
+    if tr_high is not None:
+        fig.add_hline(
+            y=tr_high,
+            line_dash="dash",
+            line_color="#d62728",
+            annotation_text="TR high",
+            annotation_position="top right",
+            row=1,
+            col=1,
+        )
+
+    for column, marker_name, marker_color, marker_symbol in [
+        ("wyckoff_event", "Wyckoff event", "#1f77b4", "circle"),
+        ("wyckoff_confirmed_event", "Confirmed event", "#9467bd", "diamond"),
+    ]:
+        events = _event_points(chart_df, column, x_values)
+        if events.empty:
+            continue
+
+        fig.add_trace(
+            go.Scatter(
+                x=events["x"],
+                y=events["high"],
+                mode="markers",
+                name=marker_name,
+                marker={"size": 8, "color": marker_color, "symbol": marker_symbol},
+                text=events["event_label"],
+                hovertemplate="%{text}<br>%{x}<br>Price: %{y}<extra></extra>",
+            ),
+            row=1,
+            col=1,
+        )
+
+    fig.update_layout(
+        title=title or "MarketFlow Annotated Candlestick",
+        height=720,
+        margin={"l": 20, "r": 20, "t": 60, "b": 20},
+        xaxis_rangeslider_visible=False,
+        legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "right", "x": 1},
+    )
+    fig.update_yaxes(title_text="Price", row=1, col=1)
+    if has_volume:
+        fig.update_yaxes(title_text="Volume", row=2, col=1)
+
+    return fig
+

--- a/marketflow/services/__init__.py
+++ b/marketflow/services/__init__.py
@@ -1,0 +1,2 @@
+"""Service helpers for lightweight MarketFlow application interfaces."""
+

--- a/marketflow/services/__init__.py
+++ b/marketflow/services/__init__.py
@@ -1,2 +1,7 @@
 """Service helpers for lightweight MarketFlow application interfaces."""
 
+__all__ = [
+    "analysis_service",
+    "report_index",
+    "strategy_service",
+]

--- a/marketflow/services/__init__.py
+++ b/marketflow/services/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "analysis_service",
+    "monte_carlo_service",
     "report_index",
     "strategy_service",
 ]

--- a/marketflow/services/analysis_service.py
+++ b/marketflow/services/analysis_service.py
@@ -1,0 +1,52 @@
+"""Application service wrapper for running MarketFlow analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from marketflow.marketflow_analysis import run_analysis
+from marketflow.services.report_index import (
+    list_report_files,
+    load_report_json,
+    load_summary_text,
+)
+
+
+def run_single_ticker(ticker: str, timeframes: list[str] | None = None) -> dict[str, Any]:
+    """Run analysis for one ticker and return a UI-friendly result dictionary."""
+    clean_ticker = (ticker or "").strip()
+    clean_timeframes = [tf.strip() for tf in (timeframes or []) if tf and tf.strip()]
+
+    if not clean_ticker:
+        return {
+            "ticker": clean_ticker,
+            "narrative": "",
+            "output_dir": None,
+            "success": False,
+            "error": "Ticker is required.",
+        }
+
+    try:
+        narrative, output_dir = run_analysis(
+            clean_ticker,
+            timeframes=clean_timeframes or None,
+        )
+        return {
+            "ticker": clean_ticker,
+            "narrative": narrative,
+            "output_dir": output_dir,
+            "success": True,
+            "error": None,
+            "report_json": load_report_json(output_dir, clean_ticker),
+            "summary_text": load_summary_text(output_dir, clean_ticker),
+            "report_files": list_report_files(output_dir),
+        }
+    except Exception as exc:
+        return {
+            "ticker": clean_ticker,
+            "narrative": "",
+            "output_dir": None,
+            "success": False,
+            "error": str(exc),
+        }
+

--- a/marketflow/services/analysis_service.py
+++ b/marketflow/services/analysis_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import traceback
 from typing import Any
 
 from marketflow.marketflow_analysis import run_analysis
@@ -12,24 +13,95 @@ from marketflow.services.report_index import (
 )
 
 
-def run_single_ticker(ticker: str, timeframes: list[str] | None = None) -> dict[str, Any]:
+TIMEFRAME_PERIODS = {
+    "1mo": "5y",
+    "1w": "2y",
+    "1d": "365d",
+    "4h": "100d",
+    "2h": "60d",
+    "1h": "40d",
+    "30m": "20d",
+    "15m": "20d",
+    "5m": "20d",
+    "1m": "20d",
+}
+
+
+def normalize_timeframes(
+    timeframes: list[str] | list[dict[str, Any]] | None,
+) -> list[dict[str, str]] | None:
+    """Normalize UI timeframe selections into MarketFlow timeframe dictionaries."""
+    if not timeframes:
+        return None
+
+    normalized: list[dict[str, str]] = []
+    unsupported: list[str] = []
+
+    for timeframe in timeframes:
+        if not timeframe:
+            continue
+
+        if isinstance(timeframe, dict):
+            interval = timeframe.get("interval")
+            period = timeframe.get("period")
+            if interval and period:
+                normalized.append(timeframe)
+                continue
+            raise ValueError(
+                "Timeframe dictionaries must include both 'interval' and 'period'."
+            )
+
+        if isinstance(timeframe, str):
+            interval = timeframe.strip()
+            if not interval:
+                continue
+
+            period = TIMEFRAME_PERIODS.get(interval)
+            if not period:
+                unsupported.append(interval)
+                continue
+
+            normalized.append({"interval": interval, "period": period})
+            continue
+
+        raise ValueError(f"Unsupported timeframe value: {timeframe!r}")
+
+    if unsupported:
+        supported = ", ".join(TIMEFRAME_PERIODS)
+        bad_values = ", ".join(unsupported)
+        raise ValueError(f"Unsupported timeframe(s): {bad_values}. Supported: {supported}.")
+
+    return normalized or None
+
+
+def _error_result(ticker: str, error: str, error_type: str) -> dict[str, Any]:
+    """Build a consistent error result for the Streamlit UI."""
+    return {
+        "ticker": ticker,
+        "narrative": "",
+        "output_dir": None,
+        "success": False,
+        "error": error,
+        "error_type": error_type,
+        "traceback": None,
+    }
+
+
+def run_single_ticker(
+    ticker: str,
+    timeframes: list[str] | list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Run analysis for one ticker and return a UI-friendly result dictionary."""
     clean_ticker = (ticker or "").strip()
-    clean_timeframes = [tf.strip() for tf in (timeframes or []) if tf and tf.strip()]
 
     if not clean_ticker:
-        return {
-            "ticker": clean_ticker,
-            "narrative": "",
-            "output_dir": None,
-            "success": False,
-            "error": "Ticker is required.",
-        }
+        return _error_result(clean_ticker, "Ticker is required.", "ValidationError")
 
     try:
+        normalized_timeframes = normalize_timeframes(timeframes)
         narrative, output_dir = run_analysis(
             clean_ticker,
-            timeframes=clean_timeframes or None,
+            timeframes=normalized_timeframes,
         )
         return {
             "ticker": clean_ticker,
@@ -37,6 +109,9 @@ def run_single_ticker(ticker: str, timeframes: list[str] | None = None) -> dict[
             "output_dir": output_dir,
             "success": True,
             "error": None,
+            "error_type": None,
+            "traceback": None,
+            "timeframes": normalized_timeframes,
             "report_json": load_report_json(output_dir, clean_ticker),
             "summary_text": load_summary_text(output_dir, clean_ticker),
             "report_files": list_report_files(output_dir),
@@ -48,5 +123,6 @@ def run_single_ticker(ticker: str, timeframes: list[str] | None = None) -> dict[
             "output_dir": None,
             "success": False,
             "error": str(exc),
+            "error_type": type(exc).__name__,
+            "traceback": traceback.format_exc(),
         }
-

--- a/marketflow/services/monte_carlo_service.py
+++ b/marketflow/services/monte_carlo_service.py
@@ -1,0 +1,174 @@
+"""Service helpers for running single-trade Monte Carlo simulations."""
+
+from __future__ import annotations
+
+import traceback
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from marketflow.services.report_index import infer_timeframe_from_csv_name
+
+
+SUPPORTED_MODELS = {"bootstrap", "gbm", "garch"}
+OPTIONAL_SIMULATOR_IMPORTS = {"arch", "lightgbm"}
+
+
+def _install_optional_dependency_stub(module_name: str) -> None:
+    """Install a minimal stub for optional simulator imports not used by simple models."""
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    def _missing_dependency(*args: Any, **kwargs: Any) -> None:
+        raise ImportError(
+            f"Optional dependency '{module_name}' is required for this Monte Carlo model."
+        )
+
+    if module_name == "arch":
+        module.arch_model = _missing_dependency
+    elif module_name == "lightgbm":
+        module.LGBMRegressor = _missing_dependency
+
+    sys.modules[module_name] = module
+
+
+def _load_simulator_class(model: str) -> Any:
+    """Load the existing simulator class while tolerating unused optional imports."""
+    if model == "garch":
+        module = importlib.import_module("marketflow.marketflow_monte_carlo_trade")
+        return module.MonteCarloTradeSimulator
+
+    for _ in range(len(OPTIONAL_SIMULATOR_IMPORTS) + 1):
+        try:
+            module = importlib.import_module("marketflow.marketflow_monte_carlo_trade")
+            return module.MonteCarloTradeSimulator
+        except ModuleNotFoundError as exc:
+            if exc.name not in OPTIONAL_SIMULATOR_IMPORTS:
+                raise
+            _install_optional_dependency_stub(exc.name)
+
+    module = importlib.import_module("marketflow.marketflow_monte_carlo_trade")
+    return module.MonteCarloTradeSimulator
+
+
+def load_latest_close(csv_path: str) -> float | None:
+    """
+    Load the latest close price from a CSV.
+
+    Return None if the file is missing, malformed, or does not contain a usable
+    close column.
+    """
+    if not csv_path:
+        return None
+
+    path = Path(csv_path)
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        last_chunk = None
+        for chunk in pd.read_csv(path, usecols=["close"], chunksize=1000):
+            last_chunk = chunk
+        if last_chunk is None or "close" not in last_chunk.columns:
+            return None
+
+        closes = pd.to_numeric(last_chunk["close"], errors="coerce").dropna()
+        if closes.empty:
+            return None
+        return float(closes.iloc[-1])
+    except Exception:
+        return None
+
+
+def run_monte_carlo_for_csv(
+    csv_path: str,
+    entry: float | None,
+    stop_loss: float,
+    take_profit: float,
+    timeframe: str | None = None,
+    model: str = "bootstrap",
+    paths: int = 10000,
+    horizon: int = 20,
+    block_len: int = 8,
+    seed: int = 42,
+    nrows: int | None = 4000,
+    save_plots: bool = True,
+) -> dict[str, Any]:
+    """
+    Run a single Monte Carlo trade simulation for one CSV.
+
+    Return a UI-friendly dictionary containing success state, structured error
+    details, the selected CSV path, inferred timeframe, and the simulator result.
+    """
+    path = Path(csv_path) if csv_path else None
+    normalized_model = (model or "").strip().lower()
+
+    try:
+        if path is None or not path.exists() or not path.is_file():
+            raise FileNotFoundError(f"CSV file does not exist: {csv_path}")
+        if normalized_model not in SUPPORTED_MODELS:
+            raise ValueError(
+                f"Unsupported Monte Carlo model '{model}'. "
+                f"Choose one of: {', '.join(sorted(SUPPORTED_MODELS))}."
+            )
+
+        entry_value = None if entry is None else float(entry)
+        stop_value = float(stop_loss)
+        take_value = float(take_profit)
+        if entry_value is not None and entry_value <= 0:
+            raise ValueError("Entry must be greater than zero.")
+        if stop_value <= 0 or take_value <= 0:
+            raise ValueError("Stop loss and take profit must be greater than zero.")
+        if entry_value is not None and stop_value >= entry_value:
+            raise ValueError("Stop loss must be below entry.")
+        if entry_value is not None and take_value <= entry_value:
+            raise ValueError("Take profit must be above entry.")
+        if int(paths) <= 0:
+            raise ValueError("Paths must be positive.")
+        if int(horizon) <= 0:
+            raise ValueError("Horizon must be positive.")
+
+        selected_timeframe = timeframe or infer_timeframe_from_csv_name(str(path))
+        MonteCarloTradeSimulator = _load_simulator_class(normalized_model)
+        simulator = MonteCarloTradeSimulator(model_type=normalized_model)
+        result = simulator.simulate_trade_for_csv(
+            csv_path=str(path),
+            tp=take_value,
+            sl=stop_value,
+            entry=entry_value,
+            tf=selected_timeframe,
+            horizon_bars=int(horizon),
+            model=normalized_model,
+            n_paths=int(paths),
+            block_len=int(block_len),
+            seed=int(seed),
+            nrows=nrows,
+            save_plots=save_plots,
+            save_json=True,
+        )
+
+        return {
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "traceback": None,
+            "csv_path": str(path),
+            "timeframe": selected_timeframe,
+            "result": result,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+            "traceback": traceback.format_exc(),
+            "csv_path": str(path) if path else csv_path,
+            "timeframe": timeframe or infer_timeframe_from_csv_name(csv_path or ""),
+            "result": None,
+        }

--- a/marketflow/services/report_index.py
+++ b/marketflow/services/report_index.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
+
 from marketflow.marketflow_config_manager import create_app_config
 from marketflow.marketflow_utils import sanitize_filename
+
+
+TIMEFRAME_TOKENS = ("1mo", "1w", "1d", "4h", "2h", "1h", "30m", "15m", "5m", "1m")
 
 
 def _report_root() -> Path:
@@ -46,6 +52,47 @@ def find_latest_ticker_report(ticker: str) -> str | None:
         return None
 
     return str(max(candidates, key=candidates.get))
+
+
+def list_report_date_folders() -> list[str]:
+    """
+    Return available date or batch folders under the configured report root.
+    Should return folder paths or names sorted newest first.
+    """
+    root = _report_root()
+    if not root.exists() or not root.is_dir():
+        return []
+
+    folders = [path for path in root.iterdir() if path.is_dir()]
+    folders.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return [str(path) for path in folders]
+
+
+def list_available_tickers(report_parent: str | None = None) -> list[str]:
+    """
+    Return available ticker folders.
+
+    If report_parent is provided, list tickers under that folder.
+    If report_parent is None, search under the configured report root.
+    """
+    if report_parent:
+        parent = Path(report_parent)
+        if not parent.exists() or not parent.is_dir():
+            return []
+        return sorted(path.name for path in parent.iterdir() if path.is_dir())
+
+    root = _report_root()
+    if not root.exists() or not root.is_dir():
+        return []
+
+    tickers: set[str] = set()
+    for path in root.rglob("*"):
+        if not path.is_dir():
+            continue
+        if any(path.glob("*_report.json")) or any(path.glob("*_summary_report.txt")):
+            tickers.add(path.name)
+
+    return sorted(tickers)
 
 
 def load_report_json(report_dir: str, ticker: str) -> dict[str, Any] | None:
@@ -92,3 +139,74 @@ def list_report_files(report_dir: str) -> list[str]:
 
     return sorted(str(item) for item in path.iterdir() if item.is_file())
 
+
+def list_annotated_csv_files(report_dir: str) -> list[str]:
+    """
+    Return CSV files in the ticker report directory that look like annotated data.
+
+    Prefer files matching *_wyckoff_annotated.csv, then include other CSV files.
+    """
+    if not report_dir:
+        return []
+
+    path = Path(report_dir)
+    if not path.exists() or not path.is_dir():
+        return []
+
+    annotated = sorted(item for item in path.glob("*_wyckoff_annotated.csv") if item.is_file())
+    annotated_set = {item.resolve() for item in annotated}
+    other_csv = sorted(
+        item
+        for item in path.glob("*.csv")
+        if item.is_file() and item.resolve() not in annotated_set
+    )
+    return [str(item) for item in [*annotated, *other_csv]]
+
+
+def infer_timeframe_from_csv_name(csv_path: str) -> str | None:
+    """
+    Infer timeframe from a CSV filename.
+
+    Examples:
+    AAPL_1d_wyckoff_annotated.csv -> 1d
+    AAPL_4h_wyckoff_annotated.csv -> 4h
+    AAPL_15m_wyckoff_annotated.csv -> 15m
+    """
+    if not csv_path:
+        return None
+
+    stem = Path(csv_path).stem
+    parts = re.split(r"[_\-.]", stem)
+    for part in reversed(parts):
+        if part in TIMEFRAME_TOKENS:
+            return part
+    return None
+
+
+def load_csv_preview(csv_path: str, nrows: int = 500) -> pd.DataFrame | None:
+    """
+    Load a CSV file safely for preview.
+
+    Prefer reading the tail of the file if possible.
+    If tail reading is inconvenient, read normally and return the last nrows.
+    Must not crash the UI.
+    Return None on failure.
+    """
+    if not csv_path:
+        return None
+
+    path = Path(csv_path)
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        nrows = max(int(nrows), 1)
+        chunks = pd.read_csv(path, chunksize=nrows)
+        last_chunk = None
+        for chunk in chunks:
+            last_chunk = chunk
+        if last_chunk is None:
+            return pd.DataFrame()
+        return last_chunk.tail(nrows)
+    except Exception:
+        return None

--- a/marketflow/services/report_index.py
+++ b/marketflow/services/report_index.py
@@ -1,0 +1,94 @@
+"""Helpers for locating and loading generated MarketFlow reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from marketflow.marketflow_config_manager import create_app_config
+from marketflow.marketflow_utils import sanitize_filename
+
+
+def _report_root() -> Path:
+    """Return the configured MarketFlow report root directory."""
+    return Path(create_app_config().REPORT_DIR)
+
+
+def _safe_ticker(ticker: str) -> str:
+    """Return the filesystem-safe ticker used by existing report generation."""
+    return sanitize_filename((ticker or "").strip())
+
+
+def find_latest_ticker_report(ticker: str) -> str | None:
+    """Find the newest generated report directory for a ticker, if one exists."""
+    safe_ticker = _safe_ticker(ticker)
+    if not safe_ticker:
+        return None
+
+    root = _report_root()
+    if not root.exists():
+        return None
+
+    candidates: dict[Path, float] = {}
+
+    for date_dir in root.iterdir():
+        ticker_dir = date_dir / safe_ticker
+        if ticker_dir.is_dir():
+            candidates[ticker_dir] = ticker_dir.stat().st_mtime
+
+    report_filename = f"{safe_ticker}_report.json"
+    for report_file in root.rglob(report_filename):
+        if report_file.is_file():
+            candidates[report_file.parent] = report_file.stat().st_mtime
+
+    if not candidates:
+        return None
+
+    return str(max(candidates, key=candidates.get))
+
+
+def load_report_json(report_dir: str, ticker: str) -> dict[str, Any] | None:
+    """Load the generated JSON report for a ticker from a report directory."""
+    if not report_dir:
+        return None
+
+    report_path = Path(report_dir) / f"{_safe_ticker(ticker)}_report.json"
+    if not report_path.exists():
+        return None
+
+    try:
+        with open(report_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def load_summary_text(report_dir: str, ticker: str) -> str | None:
+    """Load the generated text summary report for a ticker from a report directory."""
+    if not report_dir:
+        return None
+
+    report_path = Path(report_dir) / f"{_safe_ticker(ticker)}_summary_report.txt"
+    if not report_path.exists():
+        return None
+
+    try:
+        text = report_path.read_text(encoding="utf-8").strip()
+        return text or None
+    except Exception:
+        return None
+
+
+def list_report_files(report_dir: str) -> list[str]:
+    """List files generated in a report directory."""
+    if not report_dir:
+        return []
+
+    path = Path(report_dir)
+    if not path.exists() or not path.is_dir():
+        return []
+
+    return sorted(str(item) for item in path.iterdir() if item.is_file())
+

--- a/marketflow/services/report_index.py
+++ b/marketflow/services/report_index.py
@@ -210,3 +210,12 @@ def load_csv_preview(csv_path: str, nrows: int = 500) -> pd.DataFrame | None:
         return last_chunk.tail(nrows)
     except Exception:
         return None
+
+
+def load_csv_for_chart(csv_path: str, nrows: int = 1000) -> pd.DataFrame | None:
+    """
+    Load recent rows from a CSV for chart rendering.
+
+    Return None on failure.
+    """
+    return load_csv_preview(csv_path, nrows=nrows)

--- a/marketflow/services/strategy_service.py
+++ b/marketflow/services/strategy_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import traceback
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -70,6 +71,139 @@ def _results_dataframe(results: list[dict[str, Any]]) -> pd.DataFrame:
     return dataframe[[*ordered_columns, *extra_columns]]
 
 
+def find_latest_batch_folder(report_root: str) -> str | None:
+    """
+    Find latest batch_* folder under report_root.
+
+    Return path or None.
+    """
+    root = Path(report_root)
+    if not root.exists() or not root.is_dir():
+        return None
+
+    batch_folders = sorted(
+        (path for path in root.glob("batch_*") if path.is_dir()),
+        key=lambda path: path.name,
+    )
+    if not batch_folders:
+        return None
+
+    return str(batch_folders[-1])
+
+
+def _ticker_folder_candidates(report_root: str, ticker: str) -> list[Path]:
+    """Return likely report folders for a ticker under the report root."""
+    root = Path(report_root)
+    if not root.exists() or not root.is_dir():
+        return []
+
+    candidates = [path for path in root.rglob(ticker) if path.is_dir()]
+    candidates.sort(key=lambda path: path.stat().st_mtime)
+    return candidates
+
+
+def _matching_timeframe_csvs(csv_candidates: list[Path], timeframe: str) -> list[str]:
+    """Return CSV paths whose filenames match the requested timeframe token."""
+    tf = (timeframe or "").strip()
+    if not tf:
+        return []
+
+    return [
+        str(path)
+        for path in csv_candidates
+        if re.search(rf"(^|[_\-]){re.escape(tf)}([_\-.]|$)", path.stem)
+    ]
+
+
+def inspect_strategy_inputs(
+    report_root: str,
+    tickers: list[str],
+    timeframe: str,
+    min_rr: float,
+    max_sl_atr: float,
+    prefer_phases: tuple[str, ...],
+    use_mc: bool,
+) -> dict[str, Any]:
+    """
+    Inspect report folders and CSV availability before ranking.
+
+    Return diagnostics dictionary for UI troubleshooting.
+    """
+    root = Path(report_root)
+    latest_batch_folder = find_latest_batch_folder(report_root)
+    clean_tickers = normalize_tickers(tickers)
+    clean_timeframe = (timeframe or "").strip()
+
+    diagnostics: dict[str, Any] = {
+        "report_root": report_root,
+        "report_root_exists": root.exists() and root.is_dir(),
+        "requested_tickers": clean_tickers,
+        "requested_timeframe": clean_timeframe,
+        "latest_batch_folder": latest_batch_folder,
+        "latest_batch_folder_exists": bool(
+            latest_batch_folder and Path(latest_batch_folder).exists()
+        ),
+        "ticker_checks": {},
+        "filters": {
+            "min_rr": float(min_rr),
+            "max_sl_atr": float(max_sl_atr),
+            "prefer_phases": list(prefer_phases),
+            "use_mc": bool(use_mc),
+        },
+        "notes": [],
+    }
+
+    notes: list[str] = diagnostics["notes"]
+    if not diagnostics["report_root_exists"]:
+        notes.append("Report root does not exist yet. Run an analysis first.")
+        return diagnostics
+
+    if not latest_batch_folder:
+        notes.append(
+            "No batch folder found. Strategy will still search recursively under the "
+            "report root using existing strategy fallback behavior."
+        )
+
+    total_matching_csvs = 0
+    total_ticker_folders = 0
+
+    for ticker in clean_tickers:
+        folders = _ticker_folder_candidates(report_root, ticker)
+        ticker_folder = folders[-1] if folders else None
+        csv_candidates = sorted(ticker_folder.glob("*.csv")) if ticker_folder else []
+        matching_csvs = _matching_timeframe_csvs(csv_candidates, clean_timeframe)
+
+        total_ticker_folders += 1 if ticker_folder else 0
+        total_matching_csvs += len(matching_csvs)
+
+        diagnostics["ticker_checks"][ticker] = {
+            "ticker_folder_found": ticker_folder is not None,
+            "ticker_folder": str(ticker_folder) if ticker_folder else None,
+            "csv_candidates": [str(path) for path in csv_candidates],
+            "matching_timeframe_csvs": matching_csvs,
+        }
+
+        if not ticker_folder:
+            notes.append(f"No ticker folder found for {ticker}.")
+        elif not csv_candidates:
+            notes.append(f"No CSV files found in the latest {ticker} report folder.")
+        elif not matching_csvs:
+            notes.append(
+                f"No CSV files matching timeframe `{clean_timeframe}` were found for {ticker}."
+            )
+
+    if clean_tickers and total_ticker_folders == 0:
+        notes.append("No ticker folders were found for the requested tickers.")
+
+    if clean_tickers and total_matching_csvs == 0:
+        notes.append(
+            f"No CSV files matching timeframe `{clean_timeframe}` were found for the "
+            "requested tickers. Try another timeframe or run analysis first."
+        )
+
+    return diagnostics
+
+
 def rank_latest_candidates(
     tickers: list[str],
     timeframe: str,
@@ -92,13 +226,22 @@ def rank_latest_candidates(
         use_mc=use_mc,
     )
     config = asdict(cfg)
+    clean_tickers = normalize_tickers(tickers)
+    clean_timeframe = (timeframe or "").strip()
+    diagnostics = inspect_strategy_inputs(
+        report_root=report_root,
+        tickers=clean_tickers,
+        timeframe=clean_timeframe,
+        min_rr=min_rr,
+        max_sl_atr=max_sl_atr,
+        prefer_phases=prefer_phases,
+        use_mc=use_mc,
+    )
 
     try:
-        clean_tickers = normalize_tickers(tickers)
         if not clean_tickers:
             raise ValueError("At least one ticker is required.")
 
-        clean_timeframe = (timeframe or "").strip()
         if not clean_timeframe:
             raise ValueError("Timeframe is required.")
 
@@ -111,6 +254,11 @@ def rank_latest_candidates(
             use_batch_namespace="latest",
         )
         dataframe = _results_dataframe(results)
+        if not results:
+            diagnostics["notes"].append(
+                "Strategy ran successfully but returned no candidates. Filters may be too "
+                "strict, or the matching reports may not satisfy the strategy criteria."
+            )
 
         return {
             "success": True,
@@ -123,6 +271,7 @@ def rank_latest_candidates(
             "report_root": report_root,
             "tickers": clean_tickers,
             "timeframe": clean_timeframe,
+            "diagnostics": diagnostics,
         }
     except Exception as exc:
         return {
@@ -136,5 +285,5 @@ def rank_latest_candidates(
             "report_root": report_root,
             "tickers": normalize_tickers(tickers),
             "timeframe": timeframe,
+            "diagnostics": diagnostics,
         }
-

--- a/marketflow/services/strategy_service.py
+++ b/marketflow/services/strategy_service.py
@@ -1,0 +1,140 @@
+"""Service wrapper for MarketFlow strategy ranking."""
+
+from __future__ import annotations
+
+import re
+import traceback
+from dataclasses import asdict
+from typing import Any
+
+import pandas as pd
+
+from marketflow.marketflow_config_manager import create_app_config
+from marketflow.marketflow_strategy import StrategyConfig, rank_long_candidates
+
+
+STRATEGY_COLUMNS = [
+    "ticker",
+    "tf",
+    "close",
+    "sl",
+    "tp",
+    "rr",
+    "pop",
+    "phase",
+    "event",
+    "trend",
+    "score",
+    "csv",
+]
+
+
+def get_report_root() -> str:
+    """Return the configured MarketFlow report root directory."""
+    return create_app_config().REPORT_DIR
+
+
+def normalize_tickers(tickers: str | list[str] | None) -> list[str]:
+    """
+    Normalize ticker input from text or list into uppercase ticker symbols.
+
+    Accepts comma-separated or whitespace-separated strings.
+    """
+    if not tickers:
+        return []
+
+    if isinstance(tickers, str):
+        raw_tickers = re.split(r"[\s,]+", tickers)
+    else:
+        raw_tickers = tickers
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for ticker in raw_tickers:
+        clean_ticker = str(ticker).strip().upper()
+        if clean_ticker and clean_ticker not in seen:
+            normalized.append(clean_ticker)
+            seen.add(clean_ticker)
+
+    return normalized
+
+
+def _results_dataframe(results: list[dict[str, Any]]) -> pd.DataFrame:
+    """Return strategy results as a stable-column DataFrame."""
+    dataframe = pd.DataFrame(results)
+    if dataframe.empty:
+        return pd.DataFrame(columns=STRATEGY_COLUMNS)
+
+    ordered_columns = [column for column in STRATEGY_COLUMNS if column in dataframe.columns]
+    extra_columns = [column for column in dataframe.columns if column not in ordered_columns]
+    return dataframe[[*ordered_columns, *extra_columns]]
+
+
+def rank_latest_candidates(
+    tickers: list[str],
+    timeframe: str,
+    min_rr: float = 1.5,
+    max_sl_atr: float = 2.0,
+    prefer_phases: tuple[str, ...] = ("C", "D", "E"),
+    use_mc: bool = False,
+) -> dict[str, Any]:
+    """
+    Rank long candidates using the latest batch/report folder.
+
+    Return a UI-friendly dictionary with success/error metadata, raw results,
+    DataFrame output, config, and report root.
+    """
+    report_root = get_report_root()
+    cfg = StrategyConfig(
+        min_rr=min_rr,
+        max_sl_atr=max_sl_atr,
+        prefer_phases=prefer_phases,
+        use_mc=use_mc,
+    )
+    config = asdict(cfg)
+
+    try:
+        clean_tickers = normalize_tickers(tickers)
+        if not clean_tickers:
+            raise ValueError("At least one ticker is required.")
+
+        clean_timeframe = (timeframe or "").strip()
+        if not clean_timeframe:
+            raise ValueError("Timeframe is required.")
+
+        results = rank_long_candidates(
+            report_root=report_root,
+            date_glob="*",
+            tickers=clean_tickers,
+            tf=clean_timeframe,
+            cfg=cfg,
+            use_batch_namespace="latest",
+        )
+        dataframe = _results_dataframe(results)
+
+        return {
+            "success": True,
+            "error": None,
+            "error_type": None,
+            "traceback": None,
+            "results": results,
+            "dataframe": dataframe,
+            "config": config,
+            "report_root": report_root,
+            "tickers": clean_tickers,
+            "timeframe": clean_timeframe,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+            "traceback": traceback.format_exc(),
+            "results": [],
+            "dataframe": pd.DataFrame(columns=STRATEGY_COLUMNS),
+            "config": config,
+            "report_root": report_root,
+            "tickers": normalize_tickers(tickers),
+            "timeframe": timeframe,
+        }
+

--- a/marketflow/services/strategy_service.py
+++ b/marketflow/services/strategy_service.py
@@ -28,6 +28,8 @@ STRATEGY_COLUMNS = [
     "score",
     "csv",
 ]
+BATCH_RUN_PATTERN = re.compile(r"^batch_(\d{8})_(\d{6})$")
+BATCH_LIKE_PATTERN = re.compile(r"^batch_")
 
 
 def get_report_root() -> str:
@@ -71,24 +73,66 @@ def _results_dataframe(results: list[dict[str, Any]]) -> pd.DataFrame:
     return dataframe[[*ordered_columns, *extra_columns]]
 
 
-def find_latest_batch_folder(report_root: str) -> str | None:
+def is_batch_run_folder(path: str | Path) -> bool:
     """
-    Find latest batch_* folder under report_root.
+    Return True only for real batch run folders named batch_YYYYMMDD_HHMMSS.
 
-    Return path or None.
+    Excludes batch_csv_* and other summary folders.
+    """
+    path_obj = Path(path)
+    return path_obj.is_dir() and bool(BATCH_RUN_PATTERN.fullmatch(path_obj.name))
+
+
+def _batch_run_sort_key(path: Path) -> str:
+    """Return a sortable timestamp token for a valid batch run folder."""
+    match = BATCH_RUN_PATTERN.fullmatch(path.name)
+    if not match:
+        return ""
+    return "".join(match.groups())
+
+
+def list_batch_run_folders(report_root: str) -> list[str]:
+    """
+    Return valid batch run folders sorted newest first.
+
+    Only include folders matching batch_YYYYMMDD_HHMMSS.
     """
     root = Path(report_root)
     if not root.exists() or not root.is_dir():
-        return None
+        return []
 
-    batch_folders = sorted(
-        (path for path in root.glob("batch_*") if path.is_dir()),
-        key=lambda path: path.name,
-    )
+    folders = [path for path in root.iterdir() if is_batch_run_folder(path)]
+    folders.sort(key=_batch_run_sort_key, reverse=True)
+    return [str(path) for path in folders]
+
+
+def _ignored_batch_like_folders(report_root: str) -> list[str]:
+    """Return batch-like folders excluded from valid batch-run detection."""
+    root = Path(report_root)
+    if not root.exists() or not root.is_dir():
+        return []
+
+    ignored = [
+        path
+        for path in root.iterdir()
+        if path.is_dir()
+        and BATCH_LIKE_PATTERN.match(path.name)
+        and not is_batch_run_folder(path)
+    ]
+    ignored.sort(key=lambda path: path.name, reverse=True)
+    return [str(path) for path in ignored]
+
+
+def find_latest_batch_folder(report_root: str) -> str | None:
+    """
+    Find latest valid batch run folder under report_root.
+
+    Return path or None.
+    """
+    batch_folders = list_batch_run_folders(report_root)
     if not batch_folders:
         return None
-
-    return str(batch_folders[-1])
+    return batch_folders[0]
 
 
 def _ticker_folder_candidates(report_root: str, ticker: str) -> list[Path]:
@@ -130,6 +174,8 @@ def inspect_strategy_inputs(
     Return diagnostics dictionary for UI troubleshooting.
     """
     root = Path(report_root)
+    batch_run_folders = list_batch_run_folders(report_root)
+    ignored_batch_like_folders = _ignored_batch_like_folders(report_root)
     latest_batch_folder = find_latest_batch_folder(report_root)
     clean_tickers = normalize_tickers(tickers)
     clean_timeframe = (timeframe or "").strip()
@@ -143,6 +189,8 @@ def inspect_strategy_inputs(
         "latest_batch_folder_exists": bool(
             latest_batch_folder and Path(latest_batch_folder).exists()
         ),
+        "batch_run_folders": batch_run_folders,
+        "ignored_batch_like_folders": ignored_batch_like_folders,
         "ticker_checks": {},
         "filters": {
             "min_rr": float(min_rr),
@@ -159,6 +207,11 @@ def inspect_strategy_inputs(
         return diagnostics
 
     if not latest_batch_folder:
+        if ignored_batch_like_folders:
+            notes.append(
+                "Found batch-like summary folders, but no valid batch run folder "
+                "matching batch_YYYYMMDD_HHMMSS."
+            )
         notes.append(
             "No batch folder found. Strategy will still search recursively under the "
             "report root using existing strategy fallback behavior."

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,6 +95,7 @@ simplejson==3.20.1
 six==1.17.0
 sniffio==1.3.1
 soupsieve==2.6
+streamlit==1.45.1
 sympy==1.14.0
 tenacity==9.1.2
 tensorboard==2.19.0


### PR DESCRIPTION
## Summary

Adds a local Streamlit-based MarketFlow Studio interface for personal workflow use.

## Features

- Run single-ticker analysis from the UI
- Load latest generated reports
- Browse report files
- Preview annotated CSV files
- Render basic Wyckoff candlestick charts with volume
- Rank strategy candidates using existing strategy logic
- Show strategy diagnostics
- Run simple single-run Monte Carlo simulations using existing simulator

## Notes

- No core analysis behavior was changed
- Existing scripts remain available
- Monte Carlo backtest mode is not included
- Price-Volume Eigen Analyzer is not included
- Analyst Chat is not included

## Verification

- Python compile checks passed
- Streamlit app smoke-tested locally